### PR TITLE
修复 bug

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -186,7 +186,7 @@ int list_swap(list_t *list, int pos_a, int pos_b)
     //change a and b's next
     t = a->next; 
     a->next = b->next; 
-    b->next = a; 
+    b->next = t; 
     return 1; 
 }
 


### PR DESCRIPTION
change a and b's next
应该是
```
 t = a->next;
 a->next = b->next;
 b->next = t;
```
而不是
```
 t = a->next;
 a->next = b->next;
 b->next = a;
```
